### PR TITLE
Add Bitfocus Companion tally server

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,10 @@ Once you've got everything working, you may want to make the SD card read-only, 
 	sudo raspi-config
 	#Advanced, Overlay FS, Enable Overlay FS, and set boot filesystem to write-protected/read-only
 ```
+
+Remote Control PiClock via Tally Server
+---------------------------------------
+
+It's possible to remote control PiClock's behaviour using the [Tally Protocol](TallyProtocol.md); you can either write your own server or use one of the pre-existing implementations:
+
+* [Bitfocus Companion](https://bitfocus.io/companion) (since v3.4) has a basic implementation via the [simonhyde-piclock module](https://github.com/bitfocus/companion-module-simonhyde-piclock)


### PR DESCRIPTION
I'm assuming you're happy to have this sort of thing listed? Hopefully it will help uptake in the clock too.

I don't know if you want it listed on the front page or under the tally protocol docs (or a simpler pointer from one to the other).